### PR TITLE
Increase int field to long

### DIFF
--- a/src/Pipedrive.net/Models/Common/CustomFields/IntCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/IntCustomField.cs
@@ -3,9 +3,9 @@
     // int
     public class IntCustomField : ICustomField
     {
-        public int Value { get; set; }
+        public long Value { get; set; }
 
-        public IntCustomField(int value)
+        public IntCustomField(long value)
         {
             Value = value;
         }

--- a/src/Pipedrive.net/Pipedrive.csproj
+++ b/src/Pipedrive.net/Pipedrive.csproj
@@ -3,8 +3,8 @@
     <AssemblyName>Pipedrive.net</AssemblyName>
     <Title>Pipedrive.net</Title>
     <Description>Pipedrive.net is an async .NET Standard client for pipedrive.com</Description>
-    <VersionPrefix>0.0.33</VersionPrefix>
-    <Version>0.0.33</Version>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <Version>0.1.0</Version>
     <Authors>David Rouyer</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
 
@@ -12,7 +12,7 @@
     <PackageTags>pipedrive;crm</PackageTags>
     <PackageProjectUrl>https://github.com/DavidRouyer/pipedrive-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/DavidRouyer/pipedrive-dotnet/master/LICENSE</PackageLicenseUrl>
-    <PackageReleaseNotes>https://github.com/DavidRouyer/pipedrive-dotnet/releases/tag/v0.0.33</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/DavidRouyer/pipedrive-dotnet/releases/tag/v0.1.0</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/DavidRouyer/pipedrive-dotnet</RepositoryUrl>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Pipedrive allows you to enter numbers way bigger than int32 in Custom Int fields. This causes errors in the API when it happens.