### PR TITLE
Fix UpdatedProduct class to match breaking change in api

### DIFF
--- a/src/Pipedrive.net.Tests.Integration/Clients/ProductsClientTests.cs
+++ b/src/Pipedrive.net.Tests.Integration/Clients/ProductsClientTests.cs
@@ -191,7 +191,7 @@ namespace Pipedrive.Tests.Integration.Clients
                 var updatedProduct = await fixture.Edit(product.Id, editedProduct);
 
                 Assert.Equal("updated-name", updatedProduct.Name);
-                Assert.Equal(20.50M, updatedProduct.Prices["GBP"].Price);
+                Assert.Equal(20.50M, updatedProduct.Prices.First(x => x.Currency == "GBP").Price);
 
                 // Cleanup
                 await fixture.Delete(updatedProduct.Id);

--- a/src/Pipedrive.net/Models/Response/Products/UpdatedProduct.cs
+++ b/src/Pipedrive.net/Models/Response/Products/UpdatedProduct.cs
@@ -4,6 +4,6 @@ namespace Pipedrive
 {
     public class UpdatedProduct : AbstractProduct
     {
-        public Dictionary<string, ProductPrice> Prices { get; set; }
+        public List<ProductPrice> Prices { get; set; }
     }
 }


### PR DESCRIPTION
Pipedrive Breaking Change :
https://developers.pipedrive.com/changelog/post/breaking-change-in-products-endpoint-and-webhook

Affects Puts and Get on deal products since they were using the same class.

Breaking all integrations using products since this morning (Feb. 7 2022)