### PR TITLE
Add missing JsonProperty attributes to Option

### DIFF
--- a/src/Pipedrive.net/Models/Common/Option.cs
+++ b/src/Pipedrive.net/Models/Common/Option.cs
@@ -1,9 +1,13 @@
-﻿namespace Pipedrive
+﻿using Newtonsoft.Json;
+
+namespace Pipedrive
 {
     public class Option
     {
+        [JsonProperty("id")]
         public string Id { get; set; }
 
+        [JsonProperty("label")]
         public string Label { get; set; }
     }
 }


### PR DESCRIPTION
Hi!

Recently I started getting the following error from Pipedrive when updating product fields:

```
{"success":false,"error":"Options on update must use the label & id (if it is an update) key.","error_info":"Please check developers.pipedrive.com for more information about Pipedrive API.","data":null,"additional_data":null}
```

It used to work before, but turns out that Pipedrive accepts only lower case "id" and "label" from now. 

And anyway, not having the attributes here seems like an inconsistency. :slightly_smiling_face: 