### PR TITLE
Adding MarketingStatus field to Person and PersonUpdate, allowing you…

### DIFF
--- a/src/Pipedrive.net/Clients/FilesClient.cs
+++ b/src/Pipedrive.net/Clients/FilesClient.cs
@@ -81,6 +81,11 @@ namespace Pipedrive
                 content.Add(new StringContent(data.NoteId.ToString()), "note_id");
             }
 
+            if (!string.IsNullOrEmpty(data.LeadId))
+            {
+                content.Add(new StringContent(data.LeadId), "lead_id");
+            }
+
             return await ApiConnection.Post<File>(ApiUrls.Files(), content, "application/json", "multipart/form-data");
         }
 

--- a/src/Pipedrive.net/Clients/ILeadsClient.cs
+++ b/src/Pipedrive.net/Clients/ILeadsClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Pipedrive.Models.Response.Leads;
 
 namespace Pipedrive
 {
@@ -14,5 +15,7 @@ namespace Pipedrive
         Task<IReadOnlyList<Lead>> GetAll(LeadFilters filters);
 
         Task<Lead> Get(Guid id);
+
+        Task<Lead> Create(NewLead newLead);
     }
 }

--- a/src/Pipedrive.net/Clients/LeadsClient.cs
+++ b/src/Pipedrive.net/Clients/LeadsClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Pipedrive.Helpers;
+using Pipedrive.Models.Response.Leads;
 
 namespace Pipedrive
 {
@@ -38,6 +39,11 @@ namespace Pipedrive
         public Task<Lead> Get(Guid id)
         {
             return ApiConnection.Get<Lead>(ApiUrls.Lead(id));
+        }
+
+        public Task<Lead> Create(NewLead newLead)
+        {
+            return ApiConnection.Post<Lead>(ApiUrls.Leads(), newLead);
         }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/AddressCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/AddressCustomField.cs
@@ -49,5 +49,10 @@
             PostalCode = postalCode;
             FormattedAddress = formattedAddress;
         }
+
+        public override string ToString()
+        {
+            return FormattedAddress;
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/DateCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/DateCustomField.cs
@@ -10,5 +10,10 @@ namespace Pipedrive.CustomFields
         {
             Value = value;
         }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/DateRangeCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/DateRangeCustomField.cs
@@ -13,5 +13,12 @@ namespace Pipedrive.CustomFields
             StartDate = startDate;
             EndDate = endDate;
         }
+
+        public override string ToString()
+        {
+            string startDateString = StartDate.HasValue ? StartDate.Value.ToString() : "-";
+            string endDateString = EndDate.HasValue ? EndDate.Value.ToString() : "-";
+            return $"{startDateString} to {endDateString}";
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/DecimalCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/DecimalCustomField.cs
@@ -8,5 +8,10 @@
         {
             Value = value;
         }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/ICustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/ICustomField.cs
@@ -2,5 +2,6 @@
 {
     public interface ICustomField
     {
+        string ToString();
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/LongCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/LongCustomField.cs
@@ -9,5 +9,10 @@
         {
             Value = value;
         }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/MonetaryCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/MonetaryCustomField.cs
@@ -11,5 +11,10 @@
             Value = value;
             Currency = currency;
         }
+
+        public override string ToString()
+        {
+            return $"{Currency} {Value}";
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/OrganizationCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/OrganizationCustomField.cs
@@ -21,5 +21,10 @@ namespace Pipedrive.CustomFields
 
         [JsonProperty("value")]
         public long Value { get; set; }
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/PersonCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/PersonCustomField.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace Pipedrive.CustomFields
@@ -16,5 +17,10 @@ namespace Pipedrive.CustomFields
 
         [JsonProperty("value")]
         public long Value { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Name}, <{string.Join(", ", Email.Select(e => e.Value))}>";
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/StringCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/StringCustomField.cs
@@ -9,5 +9,10 @@
         {
             Value = value;
         }
+
+        public override string ToString()
+        {
+            return Value;
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/TimeCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/TimeCustomField.cs
@@ -13,5 +13,10 @@ namespace Pipedrive.CustomFields
             Value = value;
             TimezoneId = timezoneId;
         }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/TimeRangeCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/TimeRangeCustomField.cs
@@ -16,5 +16,10 @@ namespace Pipedrive.CustomFields
             EndTime = endTime;
             TimezoneId = timezoneId;
         }
+
+        public override string ToString()
+        {
+            return $"{StartTime} to {EndTime}";
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Common/CustomFields/UserCustomField.cs
+++ b/src/Pipedrive.net/Models/Common/CustomFields/UserCustomField.cs
@@ -24,5 +24,10 @@ namespace Pipedrive.CustomFields
 
         [JsonProperty("value")]
         public long Value { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Name}, <{Email}>";
+        }
     }
 }

--- a/src/Pipedrive.net/Models/Request/Files/NewFile.cs
+++ b/src/Pipedrive.net/Models/Request/Files/NewFile.cs
@@ -25,6 +25,9 @@ namespace Pipedrive
         [JsonProperty("note_id")]
         public long? NoteId { get; set; }
 
+        [JsonProperty("lead_id")]
+        public string LeadId { get; set; }
+
         public NewFile(RawFile file)
         {
             this.File = file;

--- a/src/Pipedrive.net/Models/Request/Notes/NewNote.cs
+++ b/src/Pipedrive.net/Models/Request/Notes/NewNote.cs
@@ -25,6 +25,9 @@ namespace Pipedrive
         [JsonProperty("pinned_to_person_flag")]
         public bool PinnedToPersonFlag { get; set; }
 
+        [JsonProperty("lead_id")]
+        public string LeadId { get; set; }
+
         public NewNote(string content)
         {
             Content = content;

--- a/src/Pipedrive.net/Models/Request/Persons/PersonUpdate.cs
+++ b/src/Pipedrive.net/Models/Request/Persons/PersonUpdate.cs
@@ -25,6 +25,9 @@ namespace Pipedrive
         [JsonProperty("visible_to")]
         public Visibility VisibleTo { get; set; }
 
+        [JsonProperty("marketing_status")]
+        public string MarketingStatus { get; set; }
+
         [JsonIgnore]
         public IDictionary<string, ICustomField> CustomFields { get; set; }
     }

--- a/src/Pipedrive.net/Models/Response/Leads/NewLead.cs
+++ b/src/Pipedrive.net/Models/Response/Leads/NewLead.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Pipedrive.Models.Response.Leads
+{
+    /// <summary>
+    /// https://developers.pipedrive.com/docs/api/v1/Leads#addLead
+    /// </summary>
+    /*
+     {
+          "title": "<string>",
+          "owner_id": "<integer>",
+          "label_ids": [
+            "<uuid>",
+            "<uuid>"
+          ],
+          "person_id": "<integer>",
+          "organization_id": "<integer>",
+          "value": {
+            "amount": "<number>",
+            "currency": "<string>"
+          },
+          "expected_close_date": "<date>",
+          "visible_to": "<string>",
+          "was_seen": "<boolean>"
+     }
+     */
+    public class NewLead
+    {
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("owner_id")]
+        public long OwnerId { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("creator_id")]
+        public long CreatorId { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("label_ids")]
+        public List<Guid> LabelIds { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("value")]
+        public CurrencyAmount Value { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("expected_close_date")]
+        public DateTime? ExpectedCloseDate { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("note")]
+        public string Note { get; set; }
+
+        [JsonProperty("person_id")]
+        public long PersonId { get; set; }
+
+        [JsonProperty("organization_id")]
+        public long? OrganizationId { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("is_archived")]
+        public bool IsArchived { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("source_name")]
+        public string SourceName { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("was_seen")]
+        public bool WasSeen { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("next_activity_id")]
+        public long? NextActivityId { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("add_time")]
+        public DateTime? AddTime { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("update_time")]
+        public DateTime? UpdateTime { get; set; }
+    }
+}

--- a/src/Pipedrive.net/Models/Response/Leads/NewLead.cs
+++ b/src/Pipedrive.net/Models/Response/Leads/NewLead.cs
@@ -32,7 +32,6 @@ namespace Pipedrive.Models.Response.Leads
         [JsonProperty("title")]
         public string Title { get; set; }
 
-        [JsonIgnore]
         [JsonProperty("owner_id")]
         public long OwnerId { get; set; }
 
@@ -40,7 +39,6 @@ namespace Pipedrive.Models.Response.Leads
         [JsonProperty("creator_id")]
         public long CreatorId { get; set; }
 
-        [JsonIgnore]
         [JsonProperty("label_ids")]
         public List<Guid> LabelIds { get; set; }
 

--- a/src/Pipedrive.net/Models/Response/Persons/AbstractPerson.cs
+++ b/src/Pipedrive.net/Models/Response/Persons/AbstractPerson.cs
@@ -142,5 +142,8 @@ namespace Pipedrive
 
         [JsonProperty("cc_email")]
         public string CcEmail { get; set; }
+
+        [JsonProperty("marketing_status")]
+        public string MarketingStatus { get; set; }
     }
 }

--- a/src/Pipedrive.net/Models/Response/Persons/Person.cs
+++ b/src/Pipedrive.net/Models/Response/Persons/Person.cs
@@ -21,7 +21,8 @@ namespace Pipedrive
                 OrgId = OrgId?.Value,
                 OwnerId = OwnerId?.Value,
                 VisibleTo = VisibleTo,
-                CustomFields = CustomFields
+                CustomFields = CustomFields,
+                MarketingStatus = MarketingStatus
             };
         }
     }

--- a/src/Pipedrive.net/Pipedrive.csproj
+++ b/src/Pipedrive.net/Pipedrive.csproj
@@ -29,7 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Very small change to allow get/set of MarketingStatus. 

We are populating a CRM after signup from a website and need to set MarketingStatus to subscribed. For our own IntegrationTest purposes I'd like to be able to get MarketingStatus as well

Integration tests need to be added, for example I have two persons, one unsubscribed and one subscribed. This test allows me to get and update the statuses:

```
[IntegrationTest]
public async Task CanRetrievePersonMarketingStatus()
{
    var pipedrive = Helper.GetAuthenticatedClient();

    // Assume person with Id 123 exists and has status subscribed
    var person = await pipedrive.Person.Get(123);

    Assert.Equal("person123@mycompany.com", person.Email[0].Value);
    Assert.Equal("subscribed", person.MarketingStatus);

    // Assume person with Id 456 exists and has status no_consent
    var person2 = await pipedrive.Person.Get(456);

    Assert.Equal("person456@mycompany.com", person2.Email[0].Value);
    Assert.Equal("no_consent", person2.MarketingStatus);

    // Update person 456 
    var data = person2.ToUpdate();
    Assert.Equal(data.MarketingStatus, "no_consent");
    data.MarketingStatus = "subscribed";

    var person2Updated = await pipedrive.Person.Edit(person2.Id, data);
    Assert.Equal("subscribed", person2Updated.MarketingStatus);
}
```

Now question how to reset that status for the next test. Personally I'd set it back in teardown or create the person for the test. What do you think?