### PR TITLE
Added entireCompany enum to Visibility

### DIFF
--- a/src/Pipedrive.net/Models/Common/Visibility.cs
+++ b/src/Pipedrive.net/Models/Common/Visibility.cs
@@ -3,6 +3,7 @@
     public enum Visibility
     {
         @private = 1,
-        shared = 3
+        shared = 3,
+        entireCompany = 7
     }
 }


### PR DESCRIPTION
There was no visibility enum for "Entire Company". So I added the enum value.