### PR TITLE
Make DealField OrderNr nullable

### DIFF
--- a/src/Pipedrive.net/Models/Response/Deals/DealField.cs
+++ b/src/Pipedrive.net/Models/Response/Deals/DealField.cs
@@ -13,7 +13,7 @@ namespace Pipedrive
         public string Name { get; set; }
 
         [JsonProperty("order_nr")]
-        public long OrderNr { get; set; }
+        public long? OrderNr { get; set; }
 
         [JsonProperty("field_type")]
         public FieldType FieldType { get; set; }


### PR DESCRIPTION
Hi!

Pipedrive API documentation does not seem to state that explicitly, but I am experiencing that a deal field's order nr can also be `null`.