### PR TITLE
Response elements that are now being sent back as null need to be defined as nullable.

### DIFF
--- a/src/Pipedrive.net/Models/Response/Activities/ActivityField.cs
+++ b/src/Pipedrive.net/Models/Response/Activities/ActivityField.cs
@@ -13,7 +13,7 @@ namespace Pipedrive
         public string Name { get; set; }
 
         [JsonProperty("order_nr")]
-        public long OrderNr { get; set; }
+        public long? OrderNr { get; set; }
 
         [JsonProperty("field_type")]
         public string FieldType { get; set; }
@@ -25,37 +25,37 @@ namespace Pipedrive
         public DateTime? UpdateTime { get; set; }
 
         [JsonProperty("active_flag")]
-        public bool ActiveFlag { get; set; }
+        public bool? ActiveFlag { get; set; }
 
         [JsonProperty("edit_flag")]
-        public bool EditFlag { get; set; }
+        public bool? EditFlag { get; set; }
 
         [JsonProperty("index_visible_flag")]
-        public bool IndexVisibleFlag { get; set; }
+        public bool? IndexVisibleFlag { get; set; }
 
         [JsonProperty("details_visible_flag")]
-        public bool DetailsVisibleFlag { get; set; }
+        public bool? DetailsVisibleFlag { get; set; }
 
         [JsonProperty("add_visible_flag")]
-        public bool AddVisibleFlag { get; set; }
+        public bool? AddVisibleFlag { get; set; }
 
         [JsonProperty("important_flag")]
-        public bool ImportantFlag { get; set; }
+        public bool? ImportantFlag { get; set; }
 
         [JsonProperty("bulk_edit_allowed")]
-        public bool BulkEditAllowed { get; set; }
+        public bool? BulkEditAllowed { get; set; }
 
         [JsonProperty("searchable_flag")]
-        public bool SearchableFlag { get; set; }
+        public bool? SearchableFlag { get; set; }
 
         [JsonProperty("filtering_allowed")]
-        public bool FilteringAllowed { get; set; }
+        public bool? FilteringAllowed { get; set; }
 
         [JsonProperty("sortable_flag")]
-        public bool SortableFlag { get; set; }
+        public bool? SortableFlag { get; set; }
 
         [JsonProperty("mandatory_flag")]
-        public bool MandatoryFlag { get; set; }
+        public bool? MandatoryFlag { get; set; }
 
         public IReadOnlyList<Option> Options { get; set; }
     }

--- a/src/Pipedrive.net/Models/Response/Deals/DealField.cs
+++ b/src/Pipedrive.net/Models/Response/Deals/DealField.cs
@@ -13,7 +13,7 @@ namespace Pipedrive
         public string Name { get; set; }
 
         [JsonProperty("order_nr")]
-        public long OrderNr { get; set; }
+        public long? OrderNr { get; set; }
 
         [JsonProperty("field_type")]
         public FieldType FieldType { get; set; }
@@ -25,34 +25,34 @@ namespace Pipedrive
         public DateTime? UpdateTime { get; set; }
 
         [JsonProperty("active_flag")]
-        public bool ActiveFlag { get; set; }
+        public bool? ActiveFlag { get; set; }
 
         [JsonProperty("edit_flag")]
-        public bool EditFlag { get; set; }
+        public bool? EditFlag { get; set; }
 
         [JsonProperty("index_visible_flag")]
-        public bool IndexVisibleFlag { get; set; }
+        public bool? IndexVisibleFlag { get; set; }
 
         [JsonProperty("details_visible_flag")]
-        public bool DetailsVisibleFlag { get; set; }
+        public bool? DetailsVisibleFlag { get; set; }
 
         [JsonProperty("add_visible_flag")]
-        public bool AddVisibleFlag { get; set; }
+        public bool? AddVisibleFlag { get; set; }
 
         [JsonProperty("important_flag")]
-        public bool ImportantFlag { get; set; }
+        public bool? ImportantFlag { get; set; }
 
         [JsonProperty("bulk_edit_allowed")]
-        public bool BulkEditAllowed { get; set; }
+        public bool? BulkEditAllowed { get; set; }
 
         [JsonProperty("searchable_flag")]
-        public bool SearchableFlag { get; set; }
+        public bool? SearchableFlag { get; set; }
 
         [JsonProperty("filtering_allowed")]
-        public bool FilteringAllowed { get; set; }
+        public bool? FilteringAllowed { get; set; }
 
         [JsonProperty("sortable_flag")]
-        public bool SortableFlag { get; set; }
+        public bool? SortableFlag { get; set; }
 
         [JsonProperty("use_field")]
         public string UseField { get; set; }

--- a/src/Pipedrive.net/Models/Response/NoteFields/NoteField.cs
+++ b/src/Pipedrive.net/Models/Response/NoteFields/NoteField.cs
@@ -14,15 +14,15 @@ namespace Pipedrive
         public string FieldType { get; set; }
 
         [JsonProperty("active_flag")]
-        public bool ActiveFlag { get; set; }
+        public bool? ActiveFlag { get; set; }
 
         [JsonProperty("edit_flag")]
-        public bool EditFlag { get; set; }
+        public bool? EditFlag { get; set; }
 
         [JsonProperty("bulk_edit_allowed")]
-        public bool BulkEditAllowed { get; set; }
+        public bool? BulkEditAllowed { get; set; }
 
         [JsonProperty("mandatory_flag")]
-        public bool MantatoryFlag { get; set; }
+        public bool? MantatoryFlag { get; set; }
     }
 }

--- a/src/Pipedrive.net/Models/Response/Organizations/OrganizationField.cs
+++ b/src/Pipedrive.net/Models/Response/Organizations/OrganizationField.cs
@@ -13,7 +13,7 @@ namespace Pipedrive
         public string Name { get; set; }
 
         [JsonProperty("order_nr")]
-        public long OrderNr { get; set; }
+        public long? OrderNr { get; set; }
 
         [JsonProperty("field_type")]
         public FieldType FieldType { get; set; }
@@ -25,34 +25,34 @@ namespace Pipedrive
         public DateTime? UpdateTime { get; set; }
 
         [JsonProperty("active_flag")]
-        public bool ActiveFlag { get; set; }
+        public bool? ActiveFlag { get; set; }
 
         [JsonProperty("edit_flag")]
-        public bool EditFlag { get; set; }
+        public bool? EditFlag { get; set; }
 
         [JsonProperty("index_visible_flag")]
-        public bool IndexVisibleFlag { get; set; }
+        public bool? IndexVisibleFlag { get; set; }
 
         [JsonProperty("details_visible_flag")]
-        public bool DetailsVisibleFlag { get; set; }
+        public bool? DetailsVisibleFlag { get; set; }
 
         [JsonProperty("add_visible_flag")]
-        public bool AddVisibleFlag { get; set; }
+        public bool? AddVisibleFlag { get; set; }
 
         [JsonProperty("important_flag")]
-        public bool ImportantFlag { get; set; }
+        public bool? ImportantFlag { get; set; }
 
         [JsonProperty("bulk_edit_allowed")]
-        public bool BulkEditAllowed { get; set; }
+        public bool? BulkEditAllowed { get; set; }
 
         [JsonProperty("searchable_flag")]
-        public bool SearchableFlag { get; set; }
+        public bool? SearchableFlag { get; set; }
 
         [JsonProperty("filtering_allowed")]
-        public bool FilteringAllowed { get; set; }
+        public bool? FilteringAllowed { get; set; }
 
         [JsonProperty("sortable_flag")]
-        public bool SortableFlag { get; set; }
+        public bool? SortableFlag { get; set; }
 
         [JsonProperty("use_field")]
         public string UseField { get; set; }

--- a/src/Pipedrive.net/Models/Response/Persons/PersonField.cs
+++ b/src/Pipedrive.net/Models/Response/Persons/PersonField.cs
@@ -13,7 +13,7 @@ namespace Pipedrive
         public string Name { get; set; }
 
         [JsonProperty("order_nr")]
-        public long OrderNr { get; set; }
+        public long? OrderNr { get; set; }
 
         [JsonProperty("field_type")]
         public FieldType FieldType { get; set; }
@@ -25,34 +25,34 @@ namespace Pipedrive
         public DateTime? UpdateTime { get; set; }
 
         [JsonProperty("active_flag")]
-        public bool ActiveFlag { get; set; }
+        public bool? ActiveFlag { get; set; }
 
         [JsonProperty("edit_flag")]
-        public bool EditFlag { get; set; }
+        public bool? EditFlag { get; set; }
 
         [JsonProperty("index_visible_flag")]
-        public bool IndexVisibleFlag { get; set; }
+        public bool? IndexVisibleFlag { get; set; }
 
         [JsonProperty("details_visible_flag")]
-        public bool DetailsVisibleFlag { get; set; }
+        public bool? DetailsVisibleFlag { get; set; }
 
         [JsonProperty("add_visible_flag")]
-        public bool AddVisibleFlag { get; set; }
+        public bool? AddVisibleFlag { get; set; }
 
         [JsonProperty("important_flag")]
-        public bool ImportantFlag { get; set; }
+        public bool? ImportantFlag { get; set; }
 
         [JsonProperty("bulk_edit_allowed")]
-        public bool BulkEditAllowed { get; set; }
+        public bool? BulkEditAllowed { get; set; }
 
         [JsonProperty("searchable_flag")]
-        public bool SearchableFlag { get; set; }
+        public bool? SearchableFlag { get; set; }
 
         [JsonProperty("filtering_allowed")]
-        public bool FilteringAllowed { get; set; }
+        public bool? FilteringAllowed { get; set; }
 
         [JsonProperty("sortable_flag")]
-        public bool SortableFlag { get; set; }
+        public bool? SortableFlag { get; set; }
 
         [JsonProperty("use_field")]
         public string UseField { get; set; }

--- a/src/Pipedrive.net/Models/Response/ProductFields/ProductField.cs
+++ b/src/Pipedrive.net/Models/Response/ProductFields/ProductField.cs
@@ -12,7 +12,7 @@ namespace Pipedrive
 
         public string Name { get; set; }
 
-        public long OrderNr { get; set; }
+        public long? OrderNr { get; set; }
 
         [JsonProperty("field_type")]
         public FieldType FieldType { get; set; }
@@ -24,40 +24,40 @@ namespace Pipedrive
         public DateTime? UpdateTime { get; set; }
 
         [JsonProperty("active_flag")]
-        public bool ActiveFlag { get; set; }
+        public bool? ActiveFlag { get; set; }
 
         [JsonProperty("edit_flag")]
-        public bool EditFlag { get; set; }
+        public bool? EditFlag { get; set; }
 
         [JsonProperty("index_visible_flag")]
-        public bool IndexVisibleFlag { get; set; }
+        public bool? IndexVisibleFlag { get; set; }
 
         [JsonProperty("details_visible_flag")]
-        public bool DetailsVisibleFlag { get; set; }
+        public bool? DetailsVisibleFlag { get; set; }
 
         [JsonProperty("add_visible_flag")]
-        public bool AddVisibleFlag { get; set; }
+        public bool? AddVisibleFlag { get; set; }
 
         [JsonProperty("important_flag")]
-        public bool ImportantFlag { get; set; }
+        public bool? ImportantFlag { get; set; }
 
         [JsonProperty("bulk_edit_allowed")]
-        public bool BulkEditAllowed { get; set; }
+        public bool? BulkEditAllowed { get; set; }
 
         [JsonProperty("searchable_flag")]
-        public bool SearchableFlag { get; set; }
+        public bool? SearchableFlag { get; set; }
 
         [JsonProperty("filtering_allowed")]
-        public bool FilteringAllowed { get; set; }
+        public bool? FilteringAllowed { get; set; }
 
         [JsonProperty("sortable_flag")]
-        public bool SortableFlag { get; set; }
+        public bool? SortableFlag { get; set; }
 
         [JsonProperty("options")]
         public IReadOnlyList<Option> Options { get; set; }
 
         [JsonProperty("mandatory_flag")]
-        public bool MandatoryFlag { get; set; }
+        public bool? MandatoryFlag { get; set; }
 
         public ProductFieldUpdate ToUpdate()
         {

--- a/src/Pipedrive.net/Models/Response/ProductFields/ProductField.cs
+++ b/src/Pipedrive.net/Models/Response/ProductFields/ProductField.cs
@@ -18,7 +18,7 @@ namespace Pipedrive
         public FieldType FieldType { get; set; }
 
         [JsonProperty("add_time")]
-        public DateTime AddTime { get; set; }
+        public DateTime? AddTime { get; set; }
 
         [JsonProperty("update_time")]
         public DateTime? UpdateTime { get; set; }


### PR DESCRIPTION
Since Pipedrive's API response body changed where now these field values aren't always DateTime, Boolean, and Long values. Appearing as null instead.