### PR TITLE
Fix AbstractDealProduct, DealProductUpdate, NewDealProduct to match discount breaking changes in API

### DIFF
--- a/src/Pipedrive.net.Tests.Integration/Clients/DealsClientTests.cs
+++ b/src/Pipedrive.net.Tests.Integration/Clients/DealsClientTests.cs
@@ -728,7 +728,8 @@ namespace Pipedrive.Tests.Integration.Clients
             {
                 var newDealProduct = new NewDealProduct(1, 10, 30)
                 {
-                    DiscountPercentage = 55,
+                    Discount = 55,
+                    DiscountType = "percentage",
                     EnabledFlag = true
                 };
 
@@ -742,7 +743,8 @@ namespace Pipedrive.Tests.Integration.Clients
                 Assert.Equal(10, dealProduct.ItemPrice);
                 Assert.Equal(30, dealProduct.Quantity);
                 Assert.Equal(135, dealProduct.Sum);
-                Assert.Equal(55, dealProduct.DiscountPercentage);
+                Assert.Equal(55, dealProduct.Discount);
+                Assert.Equal("percentage", dealProduct.DiscountType);
 
                 // Cleanup
                 await fixture.DeleteProduct(1, dealProduct.ProductAttachmentId.Value);
@@ -764,7 +766,8 @@ namespace Pipedrive.Tests.Integration.Clients
                     ItemPrice = 44,
                     Quantity = 1,
                     Duration = 1,
-                    DiscountPercentage = 11
+                    Discount = 11,
+                    DiscountType = "percentage"
                 };
 
                 var updatedDealProduct = await fixture.UpdateProduct(1, createdDealProduct.ProductAttachmentId.Value, dealProductUpdate);

--- a/src/Pipedrive.net/Models/Request/Deals/DealProductUpdate.cs
+++ b/src/Pipedrive.net/Models/Request/Deals/DealProductUpdate.cs
@@ -10,8 +10,11 @@ namespace Pipedrive
         [JsonProperty("quantity")]
         public long Quantity { get; set; }
 
-        [JsonProperty("discount_percentage")]
-        public decimal DiscountPercentage { get; set; }
+        [JsonProperty("discount")]
+        public decimal Discount { get; set; }
+
+        [JsonProperty("discount_type")]
+        public string DiscountType { get; set; }
 
         [JsonProperty("duration")]
         public long Duration { get; set; } = 1;

--- a/src/Pipedrive.net/Models/Request/Deals/NewDealProduct.cs
+++ b/src/Pipedrive.net/Models/Request/Deals/NewDealProduct.cs
@@ -13,8 +13,11 @@ namespace Pipedrive
         [JsonProperty("quantity")]
         public long Quantity { get; set; }
 
-        [JsonProperty("discount_percentage")]
-        public decimal DiscountPercentage { get; set; }
+        [JsonProperty("discount")]
+        public decimal Discount { get; set; }
+
+        [JsonProperty("discount_type")]
+        public string DiscountType { get; set; }
 
         [JsonProperty("duration")]
         public long Duration { get; set; } = 1;

--- a/src/Pipedrive.net/Models/Response/Products/AbstractDealProduct.cs
+++ b/src/Pipedrive.net/Models/Response/Products/AbstractDealProduct.cs
@@ -23,8 +23,11 @@ namespace Pipedrive
         [JsonProperty("item_price")]
         public decimal ItemPrice { get; set; }
 
-        [JsonProperty("discount_percentage")]
-        public decimal DiscountPercentage { get; set; }
+        [JsonProperty("discount")]
+        public decimal Discount { get; set; }
+
+        [JsonProperty("discount_type")]
+        public string DiscountType { get; set; }
 
         [JsonProperty("duration")]
         public long Duration { get; set; }


### PR DESCRIPTION
Pipedrive API update to discounts:
[https://developers.pipedrive.com/changelog/post/update-to-the-logic-of-product-discounts](url)

Affects Get, Post and Put

Property discount_percentage will be removed from API on October 25, 2023, breaking integrations that use this property.

