### PR TITLE
Make valid Search parameter

### DIFF
--- a/src/Pipedrive.net/Clients/IPersonsClient.cs
+++ b/src/Pipedrive.net/Clients/IPersonsClient.cs
@@ -14,7 +14,7 @@ namespace Pipedrive
 
         Task<IReadOnlyList<Person>> GetAllForUserId(long userId, PersonFilters filters);
 
-        Task<IReadOnlyList<SearchResult<SimplePerson>>> Search(string name, PersonSearchFilters filters);
+        Task<IReadOnlyList<SearchResult<SimplePerson>>> Search(string term, PersonSearchFilters filters);
 
         Task<Person> Get(long id);
 


### PR DESCRIPTION
the first parameter of Search methodthe first parameter of Search method is term not name. 
it's correct on implementation but is wrong on interface is term not name.  it's correct on implementation but is wrong on interface